### PR TITLE
feat: allow tournament organizer to email all registered players

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # Ignore bundler config.
 /.bundle
 
+# Ignore bundled gems installed locally.
+/vendor/bundle
+
 # Ignore all environment files.
 /.env*
 

--- a/app/controllers/tournaments_controller.rb
+++ b/app/controllers/tournaments_controller.rb
@@ -4,8 +4,9 @@ class TournamentsController < ApplicationController
   skip_before_action :authenticate_user!, only: %i[index show]
   before_action :set_tournament,
                 only: %i[show register unregister check_in open_registration lock_registration finalize next_round
-                         update]
-  before_action :authorize_admin!, only: %i[open_registration lock_registration finalize next_round update]
+                         update email_players]
+  before_action :authorize_admin!,
+                only: %i[open_registration lock_registration finalize next_round update email_players]
 
   def index
     # Populate Current.session/user even when authentication is not required
@@ -216,6 +217,32 @@ class TournamentsController < ApplicationController
 
     redirect_to tournament_path(@tournament, tab: 1, round_tab: @tournament.rounds.count - 1),
                 notice: t('tournaments.round_advanced', default: 'Moved to next round')
+  end
+
+  def email_players
+    subject = params[:email_subject].to_s.strip
+    body = params[:email_body].to_s.strip
+    admin_tab_index = @tournament.elimination? ? 3 : 4
+
+    if subject.blank? || body.blank?
+      return redirect_to tournament_path(@tournament, tab: admin_tab_index),
+                         alert: t('.blank_fields', default: 'Subject and message cannot be blank')
+    end
+
+    recipients = @tournament.registrations.includes(:user).map(&:user).uniq
+    recipients.each do |user|
+      TournamentOrganizerMailer.with(
+        tournament: @tournament,
+        user: user,
+        subject: subject,
+        body: body
+      ).message_players.deliver_later
+    end
+
+    redirect_to tournament_path(@tournament, tab: admin_tab_index),
+                notice: t('.sent',
+                          count: recipients.size,
+                          default: { one: '1 email sent', other: '%<count>s emails sent' })
   end
 
   def finalize

--- a/app/mailers/tournament_organizer_mailer.rb
+++ b/app/mailers/tournament_organizer_mailer.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class TournamentOrganizerMailer < ApplicationMailer
+  # Sent by a tournament organizer to all registered players
+  def message_players
+    @tournament = params[:tournament]
+    @organizer = @tournament.creator
+    @user = params[:user]
+    @subject = params[:subject]
+    @body = params[:body]
+    @tournament_url = tournament_url(@tournament, locale: I18n.locale)
+
+    I18n.with_locale(locale_for(@user)) do
+      mail(
+        to: @user.email,
+        reply_to: @organizer.email,
+        subject: I18n.t(
+          'mailers.tournament_organizer.message_players.subject',
+          tournament: @tournament.name,
+          subject: @subject
+        )
+      )
+    end
+  end
+
+  private
+
+  def locale_for(_user)
+    I18n.locale.presence || I18n.default_locale
+  end
+end

--- a/app/views/tournament_organizer_mailer/message_players.html.erb
+++ b/app/views/tournament_organizer_mailer/message_players.html.erb
@@ -1,0 +1,18 @@
+<p><%= t('mailers.user_notifications.hello', username: @user.username) %>,</p>
+
+<p><%= t('mailers.tournament_organizer.message_players.from_organizer_html',
+         organizer: @organizer.username,
+         tournament: @tournament.name) %></p>
+
+<div style="border-left: 3px solid #ccc; padding: 0.5rem 1rem; margin: 1rem 0;">
+  <%= simple_format(h(@body)) %>
+</div>
+
+<p>
+  <%= t('mailers.tournament_organizer.message_players.reply_to_html',
+        email: @organizer.email) %>
+</p>
+
+<p>
+  <a href="<%= @tournament_url %>"><%= @tournament.name %></a>
+</p>

--- a/app/views/tournaments/_admin_actions.html.erb
+++ b/app/views/tournaments/_admin_actions.html.erb
@@ -31,6 +31,46 @@
 
 
 
+  <div class="card" style="margin-bottom:0.5rem;">
+    <h3 style="margin:0 0 0.25rem 0; font-size:1rem; font-weight:600;">
+      <%= t('tournaments.email_players.title', default: 'Email players') %>
+    </h3>
+    <div class="card-body">
+      <p class="card-date" style="font-style:normal; margin-bottom:0.5rem;">
+        <%= t('tournaments.email_players.description',
+              organizer_email: tournament.creator.email,
+              default: 'Send a message to all registered players. Your email (%{organizer_email}) will be shown in the email so players can reply directly.') %>
+      </p>
+      <%= form_with url: email_players_tournament_path(tournament), method: :post do |f| %>
+        <div style="display:grid; gap:0.5rem;">
+          <div>
+            <label for="email_subject" class="card-date" style="font-style:normal; font-weight:600;">
+              <%= t('tournaments.email_players.subject', default: 'Subject') %>
+            </label>
+            <input type="text"
+                   id="email_subject"
+                   name="email_subject"
+                   style="width:100%;"
+                   placeholder="<%= t('tournaments.email_players.subject_placeholder', default: 'Enter subject') %>" />
+          </div>
+          <div>
+            <label for="email_body" class="card-date" style="font-style:normal; font-weight:600;">
+              <%= t('tournaments.email_players.body', default: 'Message') %>
+            </label>
+            <textarea id="email_body"
+                      name="email_body"
+                      rows="5"
+                      style="width:100%;"
+                      placeholder="<%= t('tournaments.email_players.body_placeholder', default: 'Write your message here...') %>"></textarea>
+          </div>
+          <div>
+            <%= f.submit t('tournaments.email_players.submit', default: 'Send to all players'), class: 'btn btn-primary' %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+
   <div style="flex-basis:100%; height:1px;"></div>
   <div style="width:100%;">
     <div class="card" style="margin-bottom:0.5rem;">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -278,6 +278,18 @@ en:
       type: "Tournament"
       settings: "Settings"
       online_label: "Online tournament"
+    email_players:
+      title: "Email players"
+      description: "Send a message to all registered players. Your email (%{organizer_email}) will be shown in the email so players can reply directly."
+      subject: "Subject"
+      subject_placeholder: "Enter subject"
+      body: "Message"
+      body_placeholder: "Write your message here..."
+      submit: "Send to all players"
+      sent:
+        one: "1 email sent"
+        other: "%{count} emails sent"
+      blank_fields: "Subject and message cannot be blank"
     registration_opened: "Registration is now open"
     full: "Tournament is full"
     state:
@@ -362,6 +374,11 @@ en:
       insufficient_games: "Number of games is insufficient"
       player_match_share: "One player represents more than %{percent}% of games"
   mailers:
+    tournament_organizer:
+      message_players:
+        subject: "[%{tournament}] %{subject}"
+        from_organizer_html: "Message from the organizer of <strong>%{tournament}</strong>, %{organizer}:"
+        reply_to_html: "To reply, send an email to %{email}"
     user_notifications:
       hello: "Hello %{username}"
       problem_html: "If something looks wrong, contact Marquis via the <a href=\"%{contact_url}\">contact form</a>."

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -247,6 +247,18 @@ fr:
       type: "Tournoi"
       settings: "Paramètres"
       online_label: "Tournoi en ligne"
+    email_players:
+      title: "Envoyer un email aux joueurs"
+      description: "Envoyer un message à tous les joueurs inscrits. Votre email (%{organizer_email}) sera indiqué dans l'email pour que les joueurs puissent vous répondre directement."
+      subject: "Objet"
+      subject_placeholder: "Saisissez l'objet"
+      body: "Message"
+      body_placeholder: "Rédigez votre message ici..."
+      submit: "Envoyer à tous les joueurs"
+      sent:
+        one: "1 email envoyé"
+        other: "%{count} emails envoyés"
+      blank_fields: "L'objet et le message ne peuvent pas être vides"
     registration_opened: "Les inscriptions sont maintenant ouvertes"
     full: "Le tournoi est complet"
     state:
@@ -329,6 +341,11 @@ fr:
       insufficient_games: "Nombre de matchs insuffisant"
       player_match_share: "Un joueur représente plus de %{percent}% des matchs"
   mailers:
+    tournament_organizer:
+      message_players:
+        subject: "[%{tournament}] %{subject}"
+        from_organizer_html: "Message de l'organisateur de <strong>%{tournament}</strong>, %{organizer} :"
+        reply_to_html: "Pour répondre, envoyez un email à %{email}"
     user_notifications:
       hello: "Bonjour %{username}"
       problem_html: "Si quelque chose semble incorrect, contactez Marquis via le <a href=\"%{contact_url}\">formulaire de contact</a>."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,6 +48,7 @@ Rails.application.routes.draw do
         post :lock_registration
         post :next_round
         post :finalize
+        post :email_players
       end
 
       namespace :tournament do

--- a/test/controllers/tournaments_controller_test.rb
+++ b/test/controllers/tournaments_controller_test.rb
@@ -1418,4 +1418,102 @@ class TournamentsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to tournament_path(t, locale: I18n.locale)
     assert_equal 0, t.registrations.count
   end
+
+  test 'organizer can send email to all registered players' do
+    sign_in @user
+    t = ::Tournament::Tournament.create!(
+      name: 'Email Cup',
+      description: 'X',
+      game_system: game_systems(:chess),
+      format: 'open',
+      creator: @user,
+      state: 'registration'
+    )
+    player = users(:player_two)
+    t.registrations.create!(user: player)
+
+    assert_enqueued_emails 1 do
+      post email_players_tournament_path(t, locale: I18n.locale),
+           params: { email_subject: 'Important news', email_body: 'Please check the schedule.' }
+    end
+
+    assert_redirected_to tournament_path(t, locale: I18n.locale, tab: 4)
+  end
+
+  test 'email_players enqueues one email per registered player' do
+    sign_in @user
+    t = ::Tournament::Tournament.create!(
+      name: 'Email Cup Multi',
+      description: 'X',
+      game_system: game_systems(:chess),
+      format: 'open',
+      creator: @user,
+      state: 'registration'
+    )
+    t.registrations.create!(user: users(:player_two))
+
+    assert_enqueued_emails 1 do
+      post email_players_tournament_path(t, locale: I18n.locale),
+           params: { email_subject: 'Hello', email_body: 'See you soon!' }
+    end
+  end
+
+  test 'email_players is blocked for non-organizer' do
+    sign_in users(:player_two)
+    t = ::Tournament::Tournament.create!(
+      name: 'Email Cup Guard',
+      description: 'X',
+      game_system: game_systems(:chess),
+      format: 'open',
+      creator: @user,
+      state: 'registration'
+    )
+
+    assert_no_enqueued_emails do
+      post email_players_tournament_path(t, locale: I18n.locale),
+           params: { email_subject: 'Hello', email_body: 'Unauthorized attempt' }
+    end
+
+    assert_redirected_to tournament_path(t, locale: I18n.locale)
+  end
+
+  test 'email_players requires subject and body' do
+    sign_in @user
+    t = ::Tournament::Tournament.create!(
+      name: 'Email Cup Blank',
+      description: 'X',
+      game_system: game_systems(:chess),
+      format: 'open',
+      creator: @user,
+      state: 'registration'
+    )
+    t.registrations.create!(user: users(:player_two))
+
+    assert_no_enqueued_emails do
+      post email_players_tournament_path(t, locale: I18n.locale),
+           params: { email_subject: '', email_body: 'Some content' }
+    end
+
+    assert_redirected_to tournament_path(t, locale: I18n.locale, tab: 4)
+  end
+
+  test 'email_players for elimination tournament redirects to tab 3' do
+    sign_in @user
+    t = ::Tournament::Tournament.create!(
+      name: 'Email Elim',
+      description: 'X',
+      game_system: game_systems(:chess),
+      format: 'elimination',
+      creator: @user,
+      state: 'registration'
+    )
+    t.registrations.create!(user: users(:player_two))
+
+    assert_enqueued_emails 1 do
+      post email_players_tournament_path(t, locale: I18n.locale),
+           params: { email_subject: 'Bracket info', email_body: 'Check the bracket.' }
+    end
+
+    assert_redirected_to tournament_path(t, locale: I18n.locale, tab: 3)
+  end
 end

--- a/test/mailers/tournament_organizer_mailer_test.rb
+++ b/test/mailers/tournament_organizer_mailer_test.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class TournamentOrganizerMailerTest < ActionMailer::TestCase
+  setup do
+    @organizer = users(:player_one)
+    @player = users(:player_two)
+    @system = game_systems(:chess)
+    @scoring_system = game_scoring_systems(:chess_default)
+    @tournament = Tournament::Tournament.create!(
+      name: 'Test Cup',
+      creator: @organizer,
+      game_system: @system,
+      scoring_system: @scoring_system,
+      format: :swiss,
+      state: 'registration',
+      score_for_bye: 0
+    )
+  end
+
+  test 'message_players sends to the player with correct to and reply_to' do
+    mail = TournamentOrganizerMailer.with(
+      tournament: @tournament,
+      user: @player,
+      subject: 'Important update',
+      body: 'Please check the schedule.'
+    ).message_players
+
+    assert_equal [@player.email], mail.to
+    assert_equal [@organizer.email], mail.reply_to
+  end
+
+  test 'message_players subject includes tournament name and custom subject' do
+    I18n.with_locale(:en) do
+      mail = TournamentOrganizerMailer.with(
+        tournament: @tournament,
+        user: @player,
+        subject: 'Schedule change',
+        body: 'The schedule has changed.'
+      ).message_players
+
+      assert_includes mail.subject, @tournament.name
+      assert_includes mail.subject, 'Schedule change'
+      assert_not_includes mail.subject, 'translation missing'
+    end
+  end
+
+  test 'message_players body contains organizer email for reply' do
+    mail = TournamentOrganizerMailer.with(
+      tournament: @tournament,
+      user: @player,
+      subject: 'Hello',
+      body: 'See you there!'
+    ).message_players
+
+    assert_includes mail.body.encoded, @organizer.email
+  end
+
+  test 'message_players body contains the custom message' do
+    body_text = 'Please bring your dice!'
+    mail = TournamentOrganizerMailer.with(
+      tournament: @tournament,
+      user: @player,
+      subject: 'Reminder',
+      body: body_text
+    ).message_players
+
+    assert_includes mail.body.encoded, body_text
+  end
+end


### PR DESCRIPTION
Adds a message composition form in the Administration tab of the
tournament page. The organizer can write a subject and body; on
submission, one email per registered player is queued. The email
displays the organizer's address in a reply-to header and in the
body so players can respond directly.

- New TournamentOrganizerMailer#message_players with reply_to set
- POST /tournaments/:id/email_players route (organizer-only)
- Email form partial rendered inside _admin_actions
- i18n keys added for en and fr locales
- Mailer tests and controller tests covering the happy path,
  authorization guard, blank-field validation, and elimination
  tournament tab redirect

https://claude.ai/code/session_01LyqXYcKDBa2PSspJ63bVFY