### PR TITLE
Add start date and location to tournament index cards

### DIFF
--- a/app/views/tournaments/index.html.erb
+++ b/app/views/tournaments/index.html.erb
@@ -17,9 +17,11 @@
         <div class="card-header">
           <h3><%= t.name %></h3>
           <p class="card-date"><%= t.game_system.localized_name %> · <%= t.format %> · <strong><%= t.state_label %></strong></p>
+          <%- card_meta = [(l(t.starts_at, format: :card) if t.starts_at.present?), (t.online ? I18n.t('tournaments.show.online_label') : t.location.presence)].compact %>
+          <% if card_meta.any? %><p class="card-date"><%= card_meta.join(' · ') %></p><% end %>
         </div>
         <div class="card-body">
-          <%= link_to t('tournaments.open'), tournament_path(t), class: 'btn' %>
+          <%= link_to I18n.t('tournaments.open'), tournament_path(t), class: 'btn' %>
         </div>
       </div>
     <% end %>
@@ -31,9 +33,11 @@
         <div class="card-header">
           <h3><%= t.name %></h3>
           <p class="card-date"><%= t.game_system.localized_name %> · <%= t.format %> · <strong><%= t.state_label %></strong></p>
+          <%- card_meta = [(l(t.starts_at, format: :card) if t.starts_at.present?), (t.online ? I18n.t('tournaments.show.online_label') : t.location.presence)].compact %>
+          <% if card_meta.any? %><p class="card-date"><%= card_meta.join(' · ') %></p><% end %>
         </div>
         <div class="card-body">
-          <%= link_to t('tournaments.open'), tournament_path(t), class: 'btn' %>
+          <%= link_to I18n.t('tournaments.open'), tournament_path(t), class: 'btn' %>
         </div>
       </div>
     <% end %>
@@ -45,9 +49,11 @@
         <div class="card-header">
           <h3><%= t.name %></h3>
           <p class="card-date"><%= t.game_system.localized_name %> · <%= t.format %> · <strong><%= t.state_label %></strong></p>
+          <%- card_meta = [(l(t.starts_at, format: :card) if t.starts_at.present?), (t.online ? I18n.t('tournaments.show.online_label') : t.location.presence)].compact %>
+          <% if card_meta.any? %><p class="card-date"><%= card_meta.join(' · ') %></p><% end %>
         </div>
         <div class="card-body">
-          <%= link_to t('tournaments.open'), tournament_path(t), class: 'btn' %>
+          <%= link_to I18n.t('tournaments.open'), tournament_path(t), class: 'btn' %>
         </div>
       </div>
     <% end %>
@@ -59,9 +65,11 @@
         <div class="card-header">
           <h3><%= t.name %></h3>
           <p class="card-date"><%= t.game_system.localized_name %> · <%= t.format %> · <strong><%= t.state_label %></strong></p>
+          <%- card_meta = [(l(t.starts_at, format: :card) if t.starts_at.present?), (t.online ? I18n.t('tournaments.show.online_label') : t.location.presence)].compact %>
+          <% if card_meta.any? %><p class="card-date"><%= card_meta.join(' · ') %></p><% end %>
         </div>
         <div class="card-body">
-          <%= link_to t('tournaments.open'), tournament_path(t), class: 'btn' %>
+          <%= link_to I18n.t('tournaments.open'), tournament_path(t), class: 'btn' %>
         </div>
       </div>
     <% end %>

--- a/test/controllers/tournaments_controller_test.rb
+++ b/test/controllers/tournaments_controller_test.rb
@@ -1516,4 +1516,101 @@ class TournamentsControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to tournament_path(t, locale: I18n.locale, tab: 3)
   end
+
+  test 'index card shows formatted starts_at date' do
+    tournament = ::Tournament::Tournament.create!(
+      name: 'Dated Cup',
+      description: 'Test',
+      game_system: game_systems(:chess),
+      format: 'open',
+      creator: @user,
+      state: 'registration',
+      starts_at: Time.zone.parse('2026-06-15 10:00')
+    )
+
+    get tournaments_path(locale: :en)
+    assert_response :success
+    assert_includes @response.body, I18n.l(tournament.starts_at, format: :card, locale: :en)
+  end
+
+  test 'index card shows location when set and not online' do
+    tournament = ::Tournament::Tournament.create!(
+      name: 'Location Cup',
+      description: 'Test',
+      game_system: game_systems(:chess),
+      format: 'open',
+      creator: @user,
+      state: 'registration',
+      location: 'Paris Convention Center'
+    )
+
+    get tournaments_path(locale: :en)
+    assert_response :success
+    assert_includes @response.body, 'Paris Convention Center'
+  end
+
+  test 'index card shows online label when tournament is online' do
+    tournament = ::Tournament::Tournament.create!(
+      name: 'Online Cup',
+      description: 'Test',
+      game_system: game_systems(:chess),
+      format: 'open',
+      creator: @user,
+      state: 'registration',
+      online: true
+    )
+
+    get tournaments_path(locale: :en)
+    assert_response :success
+    assert_includes @response.body, I18n.t('tournaments.show.online_label', locale: :en)
+  end
+
+  test 'index card does not show location when tournament is online' do
+    tournament = ::Tournament::Tournament.create!(
+      name: 'Online Only Cup',
+      description: 'Test',
+      game_system: game_systems(:chess),
+      format: 'open',
+      creator: @user,
+      state: 'registration',
+      online: true,
+      location: 'Should Not Appear'
+    )
+
+    get tournaments_path(locale: :en)
+    assert_response :success
+    assert_not_includes @response.body, 'Should Not Appear'
+  end
+
+  test 'index card shows no date when starts_at is nil' do
+    tournament = ::Tournament::Tournament.create!(
+      name: 'No Date Cup',
+      description: 'Test',
+      game_system: game_systems(:chess),
+      format: 'open',
+      creator: @user,
+      state: 'registration'
+    )
+
+    get tournaments_path(locale: :en)
+    assert_response :success
+    # Page renders without error; only one card-date line (game system info) appears for this tournament
+    assert_includes @response.body, 'No Date Cup'
+  end
+
+  test 'index card date uses locale-specific format in french' do
+    tournament = ::Tournament::Tournament.create!(
+      name: 'Tournoi Daté',
+      description: 'Test',
+      game_system: game_systems(:chess),
+      format: 'open',
+      creator: @user,
+      state: 'registration',
+      starts_at: Time.zone.parse('2026-06-15 10:00')
+    )
+
+    get tournaments_path(locale: :fr)
+    assert_response :success
+    assert_includes @response.body, I18n.l(tournament.starts_at, format: :card, locale: :fr)
+  end
 end

--- a/test/controllers/tournaments_controller_test.rb
+++ b/test/controllers/tournaments_controller_test.rb
@@ -1534,7 +1534,7 @@ class TournamentsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'index card shows location when set and not online' do
-    tournament = ::Tournament::Tournament.create!(
+    ::Tournament::Tournament.create!(
       name: 'Location Cup',
       description: 'Test',
       game_system: game_systems(:chess),
@@ -1550,7 +1550,7 @@ class TournamentsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'index card shows online label when tournament is online' do
-    tournament = ::Tournament::Tournament.create!(
+    ::Tournament::Tournament.create!(
       name: 'Online Cup',
       description: 'Test',
       game_system: game_systems(:chess),
@@ -1566,7 +1566,7 @@ class TournamentsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'index card does not show location when tournament is online' do
-    tournament = ::Tournament::Tournament.create!(
+    ::Tournament::Tournament.create!(
       name: 'Online Only Cup',
       description: 'Test',
       game_system: game_systems(:chess),
@@ -1583,7 +1583,7 @@ class TournamentsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'index card shows no date when starts_at is nil' do
-    tournament = ::Tournament::Tournament.create!(
+    ::Tournament::Tournament.create!(
       name: 'No Date Cup',
       description: 'Test',
       game_system: game_systems(:chess),
@@ -1594,7 +1594,7 @@ class TournamentsControllerTest < ActionDispatch::IntegrationTest
 
     get tournaments_path(locale: :en)
     assert_response :success
-    # Page renders without error; only one card-date line (game system info) appears for this tournament
+    # Page renders without error; no extra card-date line appears for this tournament
     assert_includes @response.body, 'No Date Cup'
   end
 


### PR DESCRIPTION
## Summary

- Each tournament card on the **Tournaments** index page now displays the start date (locale-aware `%d/%m/%Y` format via the existing `time.formats.card` key, e.g. `15/06/2026`) and the location or online status
- Location is shown as plain text — no Google Maps iframe on the cards
- If the tournament is marked online, the online label is shown instead of the location
- If `starts_at` is nil or neither location nor online is set, the extra line is omitted

## Test plan

- [ ] Tournament with `starts_at` + location → date and location appear in the card
- [ ] Tournament with `online: true` → online label appears, physical location does NOT
- [ ] Tournament with `starts_at` only → date appears, no location line
- [ ] Tournament with no `starts_at` → no date shown, page still renders correctly
- [ ] French locale (`/fr/tournaments`) → date formatted with `fr` locale

https://claude.ai/code/session_01UNpi11NP4eJs55txvfMeAF