### PR TITLE
Replace army list modal with dedicated full-page view in new tab

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -226,6 +226,22 @@ input:focus, select:focus, textarea:focus {
 .modal-overlay { position: fixed; inset: 0; background: rgba(0, 0, 0, 0.6); display: flex; align-items: center; justify-content: center; padding: 1rem; z-index: 9999; overscroll-behavior: contain; }
 .modal-card { background: #ffffff; border-radius: 0.75rem; padding: 2rem; width: 100%; max-width: 520px; max-height: 90vh; max-height: 90dvh; overflow-y: auto; -webkit-overflow-scrolling: touch; box-shadow: 0 10px 25px rgba(0,0,0,0.15); }
 
+/***** Army list page *****/
+.army-list-page { width: 100%; max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
+.army-list-back { margin-bottom: 1.25rem; font-size: 0.9rem; }
+.army-list-page h1 { font-size: 1.75rem; margin-bottom: 0.25rem; }
+.army-list-meta { color: var(--text-muted); font-size: 0.95rem; display: flex; flex-wrap: wrap; gap: 0.25rem 0.5rem; align-items: center; }
+.army-list-meta__player { font-weight: 700; color: var(--text-strong); }
+.army-list-meta__sep { color: var(--gray-300); }
+.army-list-divider { border: none; border-top: 1px solid var(--gray-300); margin: 1.25rem 0; }
+.army-list-pre { white-space: pre-wrap; word-break: break-word; background: var(--gray-100); border: 1px solid var(--gray-300); border-radius: 0.5rem; padding: 1.25rem; font-family: ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, monospace; font-size: 0.875rem; line-height: 1.6; margin: 0; }
+.army-list-actions { margin-top: 1rem; display: flex; justify-content: flex-end; }
+
+@media (max-width: 640px) {
+  .army-list-page { padding: 1.25rem 1rem 2.5rem; }
+  .army-list-page h1 { font-size: 1.4rem; }
+}
+
 /***** Footer *****/
 .site-footer { margin-top: 2rem; padding: 1rem; border-top: 1px solid var(--gray-300); background: #fff; }
 .footer-content { width: 100%; max-width: 960px; margin: 0 auto; padding: 0 1rem; text-align: center; color: var(--text-muted); }

--- a/app/controllers/tournament/registrations_controller.rb
+++ b/app/controllers/tournament/registrations_controller.rb
@@ -7,6 +7,8 @@ module Tournament
     before_action :set_tournament
     before_action :set_registration, only: %i[show update]
 
+    layout 'army_list', only: %i[show]
+
     def show
       return if can_view?(@registration)
 

--- a/app/views/layouts/army_list.html.erb
+++ b/app/views/layouts/army_list.html.erb
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title><%= content_for(:title) || t('app.name', default: 'Eloleague') %></title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+    <%= stylesheet_link_tag :application, "data-turbo-track": "reload" %>
+    <%= javascript_importmap_tags %>
+  </head>
+
+  <body>
+    <nav class="site-nav">
+      <%= link_to t('app.name', default: 'eloleague'), tournaments_path, class: "brand" %>
+    </nav>
+    <main>
+      <%= yield %>
+    </main>
+  </body>
+</html>

--- a/app/views/tournament/registrations/show.html.erb
+++ b/app/views/tournament/registrations/show.html.erb
@@ -3,15 +3,14 @@
     <%= link_to "← #{@tournament.name}", tournament_path(@tournament, tab: 2) %>
   </div>
 
-  <h1><%= t('tournaments.show.army_list_title', default: 'Army list') %></h1>
-
-  <div class="army-list-meta">
+  
+  <h1 class="army-list-meta">
     <span class="army-list-meta__player"><%= @registration.user.username %></span>
     <% if @registration.faction.present? %>
       <span class="army-list-meta__sep">·</span>
       <span><%= @registration.faction.localized_name(I18n.locale) %></span>
     <% end %>
-  </div>
+  </h1>
 
   <hr class="army-list-divider">
 

--- a/app/views/tournament/registrations/show.html.erb
+++ b/app/views/tournament/registrations/show.html.erb
@@ -1,28 +1,32 @@
-<%= turbo_frame_tag "modal" do %>
-  <div class="modal-overlay" data-controller="modal">
-    <div class="modal-card">
-      <h2><%= t('tournaments.show.army_list_title', default: 'Army list') %> — <%= @registration.user.username %></h2>
-
-      <% can_edit = (Current.user && (Current.user.id == @registration.user_id || Current.user.id == @tournament.creator_id)) %>
-      <% if can_edit %>
-        <%= form_with(model: @registration, url: tournament_tournament_registration_path(@tournament, @registration), method: :patch, scope: :tournament_registration) do |f| %>
-          <div class="form-group">
-            <%= f.label :army_list, t('tournaments.show.army_list_label', default: 'Your army list') %>
-            <%= f.text_area :army_list, rows: 16, style: 'width:100%;' %>
-          </div>
-          <div style="display:flex;justify-content:flex-end;gap:0.5rem;">
-            <%= link_to t('layouts.shared.cancel'), '#', data: { action: 'click->modal#close' }, class: 'btn' %>
-            <%= f.submit t('layouts.shared.save', default: 'Save'), class: 'btn btn-primary' %>
-          </div>
-        <% end %>
-      <% else %>
-        <pre style="white-space:pre-wrap; background:#f9fafb; padding:1rem; border-radius:6px;"> <%= @registration.army_list.presence || t('tournaments.show.no_army_list', default: 'No army list provided') %> </pre>
-        <div style="display:flex;justify-content:flex-end;gap:0.5rem;">
-          <%= link_to t('layouts.shared.close', default: 'Close'), '#', data: { action: 'click->modal#close' }, class: 'btn' %>
-        </div>
-      <% end %>
-    </div>
+<div class="army-list-page">
+  <div class="army-list-back">
+    <%= link_to "← #{@tournament.name}", tournament_path(@tournament, tab: 2) %>
   </div>
-<% end %>
 
+  <h1><%= t('tournaments.show.army_list_title', default: 'Army list') %></h1>
 
+  <div class="army-list-meta">
+    <span class="army-list-meta__player"><%= @registration.user.username %></span>
+    <% if @registration.faction.present? %>
+      <span class="army-list-meta__sep">·</span>
+      <span><%= @registration.faction.localized_name(I18n.locale) %></span>
+    <% end %>
+  </div>
+
+  <hr class="army-list-divider">
+
+  <% can_edit = Current.user && (Current.user.id == @registration.user_id || Current.user.id == @tournament.creator_id) %>
+  <% if can_edit %>
+    <%= form_with(model: @registration, url: tournament_tournament_registration_path(@tournament, @registration), method: :patch, scope: :tournament_registration) do |f| %>
+      <div class="form-group">
+        <%= f.label :army_list, t('tournaments.show.army_list_label', default: 'Your army list') %>
+        <%= f.text_area :army_list, rows: 24, style: 'font-family: ui-monospace, monospace; font-size: 0.875rem;' %>
+      </div>
+      <div class="army-list-actions">
+        <%= f.submit t('layouts.shared.save', default: 'Save'), class: 'btn btn-primary' %>
+      </div>
+    <% end %>
+  <% else %>
+    <pre class="army-list-pre"><%= @registration.army_list.presence || t('tournaments.show.no_army_list', default: 'No army list provided') %></pre>
+  <% end %>
+</div>

--- a/app/views/tournaments/_participants.html.erb
+++ b/app/views/tournaments/_participants.html.erb
@@ -40,12 +40,14 @@
             <%= link_to t('tournaments.show.view_army_list', default: 'Army list').html_safe,
                         tournament_tournament_registration_path(tournament, r),
                         class: 'btn',
-                        data: { turbo_frame: 'modal' } %>
+                        target: '_blank',
+                        rel: 'noopener' %>
           <% elsif Current.user && (Current.user.id == r.user_id || Current.user.id == tournament.creator_id) %>
             <%= link_to t('tournaments.show.edit_army_list', default: 'Edit list').html_safe,
                         tournament_tournament_registration_path(tournament, r),
                         class: 'btn',
-                        data: { turbo_frame: 'modal' } %>
+                        target: '_blank',
+                        rel: 'noopener' %>
           <% end %>
         </div>
       <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -220,7 +220,6 @@ en:
       move_to_next_round: "Move to next round"
       view_army_list: "Army list"
       edit_army_list: "Edit list"
-      army_list_title: "Army list"
       army_list_label: "Your army list"
       no_army_list: "No army list provided"
       standings:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -191,7 +191,6 @@ fr:
       move_to_next_round: "Passer à la ronde suivante"
       view_army_list: "Liste d'armée"
       edit_army_list: "Modifier la liste"
-      army_list_title: "Liste d'armée"
       army_list_label: "Votre liste d'armée"
       no_army_list: "Aucune liste d'armée fournie"
       standings:


### PR DESCRIPTION
- Add minimal army_list layout (eloleague header only, no full nav)
- Rewrite registrations#show as a standalone page with back link, player/faction meta, and monospace pre block
- Use layout 'army_list' on the show action so it renders outside the main chrome
- Update participant list links to target="_blank" rel="noopener" instead of turbo_frame modal

https://claude.ai/code/session_01N2HnGoi4NjA7mkKY1ijxnx