### PR TITLE
Make tournament tabs and participants panel fully responsive on mobile

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -163,6 +163,51 @@ input:focus, select:focus, textarea:focus {
 .matches-grid, #matches-list { list-style: none; padding: 0; margin: 0; display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 0.5rem; }
 .matches-grid > li, #matches-list > li { margin: 0; display: flex; justify-content: center; }
 
+/* Horizontal-scrolling tab nav */
+.tabs-nav {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+  flex-wrap: nowrap;
+}
+.tabs-nav::-webkit-scrollbar { display: none; }
+.tabs-nav .btn { white-space: nowrap; flex-shrink: 0; }
+
+@media (max-width: 640px) {
+  .tabs-nav .btn { padding: 0.5rem 0.875rem; font-size: 0.9rem; }
+}
+
+/* Participants responsive grid */
+.participants-list { display: flex; flex-direction: column; }
+.participant-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr auto;
+  column-gap: 1rem;
+  align-items: center;
+  padding: 0.375rem 0;
+  border-bottom: 1px solid var(--gray-300);
+}
+.participant-row:last-child { border-bottom: none; }
+.participant-actions { display: flex; gap: 0.5rem; justify-content: flex-end; align-items: center; }
+
+@media (max-width: 640px) {
+  .participant-row {
+    grid-template-columns: 1fr 1fr;
+    row-gap: 0.375rem;
+  }
+  .participant-actions {
+    grid-column: 1 / -1;
+    justify-content: flex-start;
+    padding-bottom: 0.375rem;
+  }
+}
+
+/* Overflow utility (used by ranking table) */
+.overflow-x-auto { overflow-x: auto; -webkit-overflow-scrolling: touch; }
+
 /***** Hero (Home) *****/
 .hero {
   position: relative;

--- a/app/views/tournaments/_participants.html.erb
+++ b/app/views/tournaments/_participants.html.erb
@@ -1,58 +1,56 @@
 <div class="card">
   <div class="card-body">
-    <div style="display:grid; grid-template-columns: 1fr 1fr auto; column-gap:1rem; row-gap:0.25rem; align-items:center;">
+    <div class="participants-list">
       <% registrations.each do |r| %>
-        <div><%= link_to r.user.username, user_path(r.user) %></div>
-        <div>
-          <% can_edit = (Current.user && (Current.user.id == r.user_id || Current.user.id == tournament.creator_id)) %>
-          <% if can_edit %>
-            <%= form_with(model: r, url: tournament_tournament_registration_path(tournament, r), method: :patch, scope: :tournament_registration) do |f| %>
-              <%= hidden_field_tag :tab, 2 %>
-              <%= f.select :faction_id,
-                           Game::Faction.where(game_system_id: tournament.game_system_id)
-                             .to_a
-                             .sort_by { |fa| fa.localized_name(I18n.locale) }
-                             .map { |fa| [fa.localized_name(I18n.locale), fa.id] },
-                           { include_blank: t('tournaments.show.select_faction', default: 'Select faction') },
-                           { onchange: 'this.form.submit()' } %>
+        <div class="participant-row">
+          <div><%= link_to r.user.username, user_path(r.user) %></div>
+          <div>
+            <% can_edit = (Current.user && (Current.user.id == r.user_id || Current.user.id == tournament.creator_id)) %>
+            <% if can_edit %>
+              <%= form_with(model: r, url: tournament_tournament_registration_path(tournament, r), method: :patch, scope: :tournament_registration) do |f| %>
+                <%= hidden_field_tag :tab, 2 %>
+                <%= f.select :faction_id,
+                             Game::Faction.where(game_system_id: tournament.game_system_id)
+                               .to_a
+                               .sort_by { |fa| fa.localized_name(I18n.locale) }
+                               .map { |fa| [fa.localized_name(I18n.locale), fa.id] },
+                             { include_blank: t('tournaments.show.select_faction', default: 'Select faction') },
+                             { onchange: 'this.form.submit()' } %>
+              <% end %>
+            <% else %>
+              <span class="card-date"><%= r.faction&.localized_name || t('tournaments.show.no_faction', default: 'No faction') %></span>
             <% end %>
-          <% else %>
-            <span class="card-date"><%= r.faction&.localized_name || t('tournaments.show.no_faction', default: 'No faction') %></span>
-          <% end %>
-        </div>
-        <div class="card-date" style="text-align:right; display:flex; gap:0.5rem; justify-content:flex-end; align-items:center;">
-          <span><%= r.status %></span>
-          <% if Current.user && Current.user.id == tournament.creator_id %>
-            <%# Admin can toggle status regardless of faction/list requirements %>
-            <% new_status = r.status == 'checked_in' ? 'pending' : 'checked_in' %>
-            <%= form_with(model: r,
-                          url: tournament_tournament_registration_path(tournament, r),
-                          method: :patch,
-                          scope: :tournament_registration) do |f| %>
-              <%= f.hidden_field :status, value: new_status %>
-              <%= hidden_field_tag :tab, 2 %>
-              <%= f.submit(new_status == 'checked_in' ? t('tournaments.show.actions.toggle_status_to_checked_in') : t('tournaments.show.actions.toggle_status_to_pending'), class: 'btn') %>
+          </div>
+          <div class="participant-actions card-date">
+            <span><%= r.status %></span>
+            <% if Current.user && Current.user.id == tournament.creator_id %>
+              <% new_status = r.status == 'checked_in' ? 'pending' : 'checked_in' %>
+              <%= form_with(model: r,
+                            url: tournament_tournament_registration_path(tournament, r),
+                            method: :patch,
+                            scope: :tournament_registration) do |f| %>
+                <%= f.hidden_field :status, value: new_status %>
+                <%= hidden_field_tag :tab, 2 %>
+                <%= f.submit(new_status == 'checked_in' ? t('tournaments.show.actions.toggle_status_to_checked_in') : t('tournaments.show.actions.toggle_status_to_pending'), class: 'btn') %>
+              <% end %>
             <% end %>
-          <% end %>
-          <%# Army list button/modal visibility %>
-          <% can_view_list = (tournament.running? || tournament.completed?) && r.army_list.present? %>
-          <% if can_view_list %>
-            <%= link_to t('tournaments.show.view_army_list', default: 'Army list').html_safe,
-                        tournament_tournament_registration_path(tournament, r),
-                        class: 'btn',
-                        target: '_blank',
-                        rel: 'noopener' %>
-          <% elsif Current.user && (Current.user.id == r.user_id || Current.user.id == tournament.creator_id) %>
-            <%= link_to t('tournaments.show.edit_army_list', default: 'Edit list').html_safe,
-                        tournament_tournament_registration_path(tournament, r),
-                        class: 'btn',
-                        target: '_blank',
-                        rel: 'noopener' %>
-          <% end %>
+            <% can_view_list = (tournament.running? || tournament.completed?) && r.army_list.present? %>
+            <% if can_view_list %>
+              <%= link_to t('tournaments.show.view_army_list', default: 'Army list').html_safe,
+                          tournament_tournament_registration_path(tournament, r),
+                          class: 'btn',
+                          target: '_blank',
+                          rel: 'noopener' %>
+            <% elsif Current.user && (Current.user.id == r.user_id || Current.user.id == tournament.creator_id) %>
+              <%= link_to t('tournaments.show.edit_army_list', default: 'Edit list').html_safe,
+                          tournament_tournament_registration_path(tournament, r),
+                          class: 'btn',
+                          target: '_blank',
+                          rel: 'noopener' %>
+            <% end %>
+          </div>
         </div>
       <% end %>
     </div>
   </div>
-  </div>
-
-
+</div>

--- a/app/views/tournaments/_swiss_panels.html.erb
+++ b/app/views/tournaments/_swiss_panels.html.erb
@@ -8,7 +8,7 @@
   <div data-controller="tabs"
        data-tabs-active-index-value="<%= @active_round_index %>"
        data-tabs-param-name-value="round_tab">
-    <div style="display:flex; gap:0.5rem; margin-bottom:0.75rem; flex-wrap:wrap;">
+    <div class="tabs-nav">
       <% rounds.each_with_index do |round, idx| %>
         <a href="#"
            data-action="click->tabs#select"

--- a/app/views/tournaments/_tabs_header.html.erb
+++ b/app/views/tournaments/_tabs_header.html.erb
@@ -1,4 +1,4 @@
-<div style="display:flex; gap:0.5rem; margin-bottom:0.75rem; flex-wrap:wrap;">
+<div class="tabs-nav">
   <a href="<%= tournament_path(tournament, tab: 0) %>" data-action="click->tabs#select" data-index="0" data-tabs-target="tab" class="btn btn-primary" aria-selected="true"><%= t('tournaments.show.tabs.overview', default: 'Overview') %></a>
   <% if tournament.elimination? %>
     <a href="<%= tournament_path(tournament, tab: 1) %>" data-action="click->tabs#select" data-index="1" data-tabs-target="tab" class="btn" aria-selected="false"><%= t('tournaments.show.tabs.bracket', default: 'Bracket') %></a>


### PR DESCRIPTION
- Replace flex-wrap tabs with horizontal-scroll .tabs-nav (no awkward line breaks)
- Participants grid collapses from 3-col to 2-col on mobile with actions spanning full width
- Add .overflow-x-auto utility so ranking table scrolls on small screens
- Round tabs inside Swiss panel also use .tabs-nav

https://claude.ai/code/session_01GaWqDRddUsDgkEvpijrhvF