### PR TITLE
Fix: ne pas afficher 'Finaliser' en mode registration

### DIFF
--- a/app/views/tournaments/_admin_actions.html.erb
+++ b/app/views/tournaments/_admin_actions.html.erb
@@ -9,9 +9,7 @@
       <% elsif tournament.registration? %>
         <span class="card-date" style="font-style:normal;"><%= t('tournaments.show.lock_warning') %></span>
         <%= button_to t('tournaments.show.lock_registration'), lock_registration_tournament_path(tournament), method: :post, class: 'btn' %>
-      <% end %>
-
-      <% if tournament.running? %>
+      <% elsif tournament.running? %>
         <%# Only show next-round button section where relevant; only swiss admin need this %>
         <% if tournament.swiss? %>
           <% if can_move_to_next_round %>


### PR DESCRIPTION
Les deux blocs if séparés (registration et running) sont fusionnés en un seul if/elsif/elsif pour garantir qu'un seul ensemble d'actions admin est affiché à la fois. Le bouton 'Finaliser' ne peut donc plus apparaître quand le tournoi est en mode 'registration'.

https://claude.ai/code/session_01BV8bEvmXdw7gpeJcZtfHqz